### PR TITLE
Refactor questionnaire and product components

### DIFF
--- a/src/entities/product/ui/List/Item/index.tsx
+++ b/src/entities/product/ui/List/Item/index.tsx
@@ -13,35 +13,29 @@ interface IProductListItemProps {
   onClickFavourite?: () => void
 }
 
-const areEqual = (
-  prevProps: IProductListItemProps,
-  nextProps: IProductListItemProps
-) =>
-  prevProps.isFavourite === nextProps.isFavourite &&
-  prevProps.onClickFavourite?.toString() ===
-    nextProps.onClickFavourite?.toString()
-
-export const ProductListItem: FC<IProductListItemProps> = React.memo(
-  ({title, image, price, oldPrice, isFavourite = false, onClickFavourite}) => (
-    <div className={styles.main}>
-      <div className={styles.imgWrapper}>
-        <div className={styles.favourite} onClick={onClickFavourite}>
-          <HeartIcon isActive={isFavourite} />
-        </div>
-        <img src={image} alt="" className={styles.img} />
+export const ProductListItem: FC<IProductListItemProps> = ({
+  title,
+  image,
+  price,
+  oldPrice,
+  isFavourite = false,
+  onClickFavourite,
+}) => (
+  <div className={styles.main}>
+    <div className={styles.imgWrapper}>
+      <div className={styles.favourite} onClick={onClickFavourite}>
+        <HeartIcon isActive={isFavourite} />
       </div>
-      <div className={styles.description}>
-        <span className={styles.title}>{title}</span>
-        <div className={styles.priceBlock}>
-          {oldPrice && <span className={styles.oldPrice}>{oldPrice}</span>}
-          <span className={styles.price}>
-            {price} <span className={styles.wallet}> руб.</span>
-          </span>
-        </div>
+      <img src={image} alt="" className={styles.img} />
+    </div>
+    <div className={styles.description}>
+      <span className={styles.title}>{title}</span>
+      <div className={styles.priceBlock}>
+        {oldPrice && <span className={styles.oldPrice}>{oldPrice}</span>}
+        <span className={styles.price}>
+          {price} <span className={styles.wallet}> руб.</span>
+        </span>
       </div>
     </div>
-  ),
-  areEqual
+  </div>
 )
-
-ProductListItem.displayName = "ProductListItem"

--- a/src/entities/product/ui/List/index.tsx
+++ b/src/entities/product/ui/List/index.tsx
@@ -1,6 +1,6 @@
 import styles from "./ProductList.module.scss"
 
-import React, {useCallback, useState} from "react"
+import React, {useCallback, useMemo, useState} from "react"
 
 import {ProductListItem} from "./Item"
 import data from "./products.json"
@@ -8,13 +8,21 @@ import data from "./products.json"
 import {usePagination} from "@shared/hooks"
 import {Pagination} from "@shared/ui"
 
+interface Product {
+  id: number
+  title: string
+  image: string
+  price: number
+  oldPrice: number | null
+}
+
 const PAGE_SIZE = 10
 const SIBLING_COUNT = 1
 
 export const ProductList = () => {
   const [currentPage, setCurrentPage] = useState(1)
   const [favouriteItems, setFavouriteItems] = useState<number[]>([])
-  const paginationRang = usePagination({
+  const paginationRange = usePagination({
     currentPage,
     totalCount: data.length,
     siblingCount: SIBLING_COUNT,
@@ -29,41 +37,37 @@ export const ProductList = () => {
   const lastIndex = currentPage * PAGE_SIZE
   const firstIndex = lastIndex - PAGE_SIZE
 
-  const mappedItems = data.map((el, index) => {
-    if (index >= firstIndex && index < lastIndex) {
-      const isFavouriteItem = favouriteItems.includes(el.id)
+  const paginatedItems = useMemo<Product[]>(
+    () => data.slice(firstIndex, lastIndex),
+    [firstIndex, lastIndex]
+  )
 
-      const handleAddFavouriteItem = () => {
-        if (!favouriteItems.includes(el.id)) {
-          setFavouriteItems(prevState => [...prevState, el.id])
-        }
-        if (favouriteItems.includes(el.id)) {
-          setFavouriteItems(prevState =>
-            prevState.filter(item => item !== el.id)
-          )
-        }
-      }
-      return (
-        <ProductListItem
-          price={el.price}
-          title={el.title}
-          image={el.image}
-          key={el.id}
-          isFavourite={isFavouriteItem}
-          oldPrice={el.oldPrice}
-          onClickFavourite={handleAddFavouriteItem}
-        />
-      )
-    }
-    return null
-  })
+  const toggleFavourite = useCallback((id: number) => {
+    setFavouriteItems(prevState =>
+      prevState.includes(id)
+        ? prevState.filter(item => item !== id)
+        : [...prevState, id]
+    )
+  }, [])
+
+  const mappedItems = paginatedItems.map(product => (
+    <ProductListItem
+      price={product.price}
+      title={product.title}
+      image={product.image}
+      key={product.id}
+      isFavourite={favouriteItems.includes(product.id)}
+      oldPrice={product.oldPrice}
+      onClickFavourite={() => toggleFavourite(product.id)}
+    />
+  ))
 
   return (
     <div className={styles.main}>
       <div className={styles.content}>{mappedItems}</div>
       <Pagination
         currentPage={currentPage}
-        data={paginationRang}
+        data={paginationRange}
         onChange={handleChangePage}
       />
     </div>

--- a/src/entities/questions/index.ts
+++ b/src/entities/questions/index.ts
@@ -1,1 +1,2 @@
 export * from "./ui"
+export * from "./types"

--- a/src/entities/questions/types.ts
+++ b/src/entities/questions/types.ts
@@ -1,0 +1,11 @@
+export interface Question {
+  id: number
+  title: string
+  answers: string[]
+}
+
+export interface AnsweredQuestion {
+  id: number
+  title: string
+  answer: string | null
+}

--- a/src/entities/questions/ui/List/index.tsx
+++ b/src/entities/questions/ui/List/index.tsx
@@ -1,45 +1,45 @@
 import styles from "./QuestionsList.module.scss"
 
-import React, {FC, useEffect, useState} from "react"
+import React, {FC, useEffect, useMemo, useState} from "react"
 
 import cn from "classnames"
 
 import {CircleStages} from "@shared/ui"
 import {RadioSelect} from "@shared/ui/RadioSelect"
 
-interface IQuestionList {
-  id: number
-  title: string
-  answers: string[]
-}
-
-interface IAnswerList {
-  id: number
-  title: string
-  answer: string | null
-}
+import {AnsweredQuestion, Question} from "../../types"
 
 interface IQuestionsListProps {
-  data: IQuestionList[]
+  data: Question[]
   onSubmit: () => void
 }
 
 export const QuestionsList: FC<IQuestionsListProps> = ({data, onSubmit}) => {
   const [selectedIndex, setSelectedIndex] = useState(0)
-  const [answers, setAnswers] = useState<IAnswerList[]>()
+  const [answers, setAnswers] = useState<AnsweredQuestion[]>([])
   const [error, setError] = useState(false)
 
+  const initialAnswers = useMemo<AnsweredQuestion[]>(
+    () => data.map(({id, title}) => ({id, title, answer: null})),
+    [data]
+  )
+
   useEffect(() => {
-    setAnswers(data.map(el => ({id: el.id, title: el.title, answer: null})))
-  }, [data])
+    setAnswers(initialAnswers)
+    setSelectedIndex(0)
+    setError(false)
+  }, [initialAnswers])
 
   const handleSetNextIndex = () => {
-    if (answers && answers[selectedIndex].answer !== null) {
-      setSelectedIndex(prevState => prevState + 1)
-      setError(false)
-    } else {
+    const hasAnswer = answers[selectedIndex]?.answer !== null
+
+    if (!hasAnswer) {
       setError(true)
+      return
     }
+
+    setSelectedIndex(prevState => Math.min(prevState + 1, data.length - 1))
+    setError(false)
   }
   const handleSetPrevIndex = () => {
     if (selectedIndex > 0) {
@@ -49,33 +49,37 @@ export const QuestionsList: FC<IQuestionsListProps> = ({data, onSubmit}) => {
   }
 
   const handleSetAnswer = (value: string) => {
-    if (answers) {
-      const newArray: IAnswerList[] = [...answers]
-      newArray[selectedIndex].answer = value
-      setAnswers(newArray)
-    }
+    setAnswers(prevState =>
+      prevState.map((answer, index) =>
+        index === selectedIndex ? {...answer, answer: value} : answer
+      )
+    )
+    setError(false)
   }
 
   const handleSubmit = () => {
-    if (answers && answers[selectedIndex].answer !== null) {
-      onSubmit()
-      setError(false)
-    } else {
+    const hasAnswer = answers[selectedIndex]?.answer !== null
+
+    if (!hasAnswer) {
       setError(true)
+      return
     }
+
+    onSubmit()
+    setError(false)
   }
 
-  const radioSelectDefaultValue =
-    (answers && answers[selectedIndex]?.answer) ?? ""
+  const currentQuestion = data[selectedIndex]
+  const radioSelectDefaultValue = answers[selectedIndex]?.answer ?? ""
 
   return (
     <div className={styles.main}>
       <div className={styles.content}>
         <CircleStages countItems={data.length} selectedItem={selectedIndex} />
-        <span className={styles.title}>{data[selectedIndex].title}</span>
+        <span className={styles.title}>{currentQuestion.title}</span>
         <div className={styles.radioSelect}>
           <RadioSelect
-            data={data[selectedIndex].answers}
+            data={currentQuestion.answers}
             defaultValue={radioSelectDefaultValue}
             onChange={handleSetAnswer}
           />

--- a/src/shared/hooks/index.ts
+++ b/src/shared/hooks/index.ts
@@ -1,1 +1,1 @@
-export {usePagination} from "./usePagination"
+export {DOTS, usePagination} from "./usePagination"

--- a/src/shared/hooks/usePagination.tsx
+++ b/src/shared/hooks/usePagination.tsx
@@ -21,7 +21,6 @@ export const usePagination = ({
   siblingCount = 1,
   currentPage,
 }: IUsePagination): Array<string | number> => {
-  // eslint-disable-next-line consistent-return
   const paginationRange = useMemo(() => {
     const totalPageCount = Math.ceil(totalCount / pageSize)
 
@@ -64,7 +63,9 @@ export const usePagination = ({
       const middleRange = range(leftSiblingIndex, rightSiblingIndex)
       return [firstPageIndex, DOTS, ...middleRange, DOTS, lastPageIndex]
     }
+
+    return []
   }, [totalCount, pageSize, siblingCount, currentPage])
 
-  return paginationRange ?? []
+  return paginationRange
 }

--- a/src/shared/ui/Container/index.tsx
+++ b/src/shared/ui/Container/index.tsx
@@ -10,5 +10,5 @@ interface IContainerProps {
 }
 
 export const Container: FC<IContainerProps> = ({className, children}) => (
-  <div className={cn(className, styles.main)}>{children}</div>
+  <div className={cn(styles.main, className)}>{children}</div>
 )

--- a/src/shared/ui/Pagination/index.tsx
+++ b/src/shared/ui/Pagination/index.tsx
@@ -4,6 +4,8 @@ import React, {FC} from "react"
 
 import cn from "classnames"
 
+import {DOTS} from "@shared/hooks"
+
 interface IPaginationProps {
   currentPage: number
   data: (string | number)[]
@@ -14,17 +16,17 @@ export const Pagination: FC<IPaginationProps> = React.memo(
   ({data, currentPage, onChange}) => {
     const mappedItems = data.map((el, index) => {
       const handleChangePage = () => {
-        if (el !== "..." && onChange) {
+        if (el !== DOTS && onChange) {
           onChange(el as number)
         }
       }
 
       const itemClasses = cn(styles.item, {
         [styles.active]: el === currentPage,
-        [styles.dots]: el === "...",
+        [styles.dots]: el === DOTS,
       })
       return (
-        <div key={index} onClick={handleChangePage} className={itemClasses}>
+        <div key={`${el}-${index}`} onClick={handleChangePage} className={itemClasses}>
           {el}
         </div>
       )

--- a/src/shared/ui/RadioSelect/index.tsx
+++ b/src/shared/ui/RadioSelect/index.tsx
@@ -17,25 +17,27 @@ export const RadioSelect: FC<IRadioSelect> = ({
   defaultValue,
   onChange,
 }) => {
-  const [selectedValue, setSelectedValue] = useState<string>()
+  const [selectedValue, setSelectedValue] = useState<string>(
+    defaultValue ?? ""
+  )
 
   useEffect(() => {
-    setSelectedValue(defaultValue)
+    setSelectedValue(defaultValue ?? "")
   }, [defaultValue])
 
-  const mappedItems = data.map((el, index) => {
+  const mappedItems = data.map(el => {
     const handleSetSelectedValue = () => {
-      if (el !== defaultValue) {
-        setSelectedValue(el)
-        if (onChange) {
-          onChange(el)
-        }
+      if (el === selectedValue) return
+
+      setSelectedValue(el)
+      if (onChange) {
+        onChange(el)
       }
     }
 
     return (
       <div
-        key={index}
+        key={el}
         className={cn(styles.item, {[styles.active]: el === selectedValue})}
         onClick={handleSetSelectedValue}
       >

--- a/src/widgets/BeautyQuestionsBlock/ui/index.tsx
+++ b/src/widgets/BeautyQuestionsBlock/ui/index.tsx
@@ -1,11 +1,15 @@
 "use client"
 
-import React, {useState} from "react"
+import React, {useMemo, useState} from "react"
 
 import {ProductList} from "@entities/product"
-import {QuestionsList, QuestionsListWrapper} from "@entities/questions"
+import {
+  Question,
+  QuestionsList,
+  QuestionsListWrapper,
+} from "@entities/questions"
 
-const QuestionsListData = [
+const QUESTIONS_LIST_DATA: Question[] = [
   {
     id: 1,
     title: "Сколько вам лет?",
@@ -32,19 +36,29 @@ const QuestionsListData = [
 export const BeautyQuestionsBlock = () => {
   const [isSubmitted, setIsSubmitted] = useState(false)
 
+  const {title, description} = useMemo(() => {
+    if (isSubmitted) {
+      return {
+        title: "Результат",
+        description: "Мы подобрали для вас наиболее подходящие средства",
+      }
+    }
+
+    return {
+      title: "Онлайн-подбор средств для лица",
+      description:
+        "Пройдите короткий тест и получите список наиболее подходящих для вас косметических продуктов",
+    }
+  }, [isSubmitted])
+
   const handleSubmit = () => {
     setIsSubmitted(true)
   }
 
-  const title = isSubmitted ? "Результат" : "Онлайн-подбор средств для лица"
-  const description = isSubmitted
-    ? "Мы подобрали для вас наиболее подходящие средства"
-    : "Пройдите короткий тест и получите список наиболее подходящих для вас косметических продуктов"
-
   const content = isSubmitted ? (
     <ProductList />
   ) : (
-    <QuestionsList data={QuestionsListData} onSubmit={handleSubmit} />
+    <QuestionsList data={QUESTIONS_LIST_DATA} onSubmit={handleSubmit} />
   )
 
   return (


### PR DESCRIPTION
## Summary
- add shared question typings and memoized copy for the questionnaire block
- simplify questionnaire navigation/error handling and tighten pagination utilities
- streamline product list pagination/favourites logic and clean shared UI components

## Testing
- yarn lint (fails: hangs in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a3d75b47883248df76e1f2590aa0b)