### PR TITLE
Refine question flow and product list

### DIFF
--- a/src/entities/product/ui/List/Item/index.tsx
+++ b/src/entities/product/ui/List/Item/index.tsx
@@ -1,6 +1,8 @@
 import styles from "./Item.module.scss"
 
-import React, {FC} from "react"
+import React, {FC, useMemo} from "react"
+
+import Image from "next/image"
 
 import {HeartIcon} from "./icons"
 
@@ -18,29 +20,45 @@ const areEqual = (
   nextProps: IProductListItemProps
 ) =>
   prevProps.isFavourite === nextProps.isFavourite &&
-  prevProps.onClickFavourite?.toString() ===
-    nextProps.onClickFavourite?.toString()
+  prevProps.price === nextProps.price &&
+  prevProps.oldPrice === nextProps.oldPrice &&
+  prevProps.title === nextProps.title &&
+  prevProps.image === nextProps.image &&
+  prevProps.onClickFavourite === nextProps.onClickFavourite
 
 export const ProductListItem: FC<IProductListItemProps> = React.memo(
-  ({title, image, price, oldPrice, isFavourite = false, onClickFavourite}) => (
-    <div className={styles.main}>
-      <div className={styles.imgWrapper}>
-        <div className={styles.favourite} onClick={onClickFavourite}>
-          <HeartIcon isActive={isFavourite} />
+  ({title, image, price, oldPrice, isFavourite = false, onClickFavourite}) => {
+    const normalizedImage = useMemo(
+      () => (image.startsWith("/") ? image : image.replace(/^\.\/?/, "/")),
+      [image]
+    )
+
+    return (
+      <div className={styles.main}>
+        <div className={styles.imgWrapper}>
+          <div className={styles.favourite} onClick={onClickFavourite}>
+            <HeartIcon isActive={isFavourite} />
+          </div>
+          <Image
+            src={normalizedImage}
+            alt={title}
+            width={240}
+            height={240}
+            className={styles.img}
+          />
         </div>
-        <img src={image} alt="" className={styles.img} />
-      </div>
-      <div className={styles.description}>
-        <span className={styles.title}>{title}</span>
-        <div className={styles.priceBlock}>
-          {oldPrice && <span className={styles.oldPrice}>{oldPrice}</span>}
-          <span className={styles.price}>
-            {price} <span className={styles.wallet}> руб.</span>
-          </span>
+        <div className={styles.description}>
+          <span className={styles.title}>{title}</span>
+          <div className={styles.priceBlock}>
+            {oldPrice && <span className={styles.oldPrice}>{oldPrice}</span>}
+            <span className={styles.price}>
+              {price} <span className={styles.wallet}> руб.</span>
+            </span>
+          </div>
         </div>
       </div>
-    </div>
-  ),
+    )
+  },
   areEqual
 )
 

--- a/src/entities/product/ui/List/index.tsx
+++ b/src/entities/product/ui/List/index.tsx
@@ -14,7 +14,7 @@ const SIBLING_COUNT = 1
 export const ProductList = () => {
   const [currentPage, setCurrentPage] = useState(1)
   const [favouriteItems, setFavouriteItems] = useState<number[]>([])
-  const paginationRang = usePagination({
+  const paginationRange = usePagination({
     currentPage,
     totalCount: data.length,
     siblingCount: SIBLING_COUNT,
@@ -29,33 +29,29 @@ export const ProductList = () => {
   const lastIndex = currentPage * PAGE_SIZE
   const firstIndex = lastIndex - PAGE_SIZE
 
-  const mappedItems = data.map((el, index) => {
-    if (index >= firstIndex && index < lastIndex) {
-      const isFavouriteItem = favouriteItems.includes(el.id)
+  const currentItems = data.slice(firstIndex, lastIndex)
 
-      const handleAddFavouriteItem = () => {
-        if (!favouriteItems.includes(el.id)) {
-          setFavouriteItems(prevState => [...prevState, el.id])
-        }
-        if (favouriteItems.includes(el.id)) {
-          setFavouriteItems(prevState =>
-            prevState.filter(item => item !== el.id)
-          )
-        }
-      }
-      return (
-        <ProductListItem
-          price={el.price}
-          title={el.title}
-          image={el.image}
-          key={el.id}
-          isFavourite={isFavouriteItem}
-          oldPrice={el.oldPrice}
-          onClickFavourite={handleAddFavouriteItem}
-        />
+  const mappedItems = currentItems.map(product => {
+    const isFavouriteItem = favouriteItems.includes(product.id)
+
+    const handleToggleFavourite = () =>
+      setFavouriteItems(prevState =>
+        prevState.includes(product.id)
+          ? prevState.filter(id => id !== product.id)
+          : [...prevState, product.id]
       )
-    }
-    return null
+
+    return (
+      <ProductListItem
+        key={product.id}
+        price={product.price}
+        title={product.title}
+        image={product.image}
+        isFavourite={isFavouriteItem}
+        oldPrice={product.oldPrice}
+        onClickFavourite={handleToggleFavourite}
+      />
+    )
   })
 
   return (
@@ -63,7 +59,7 @@ export const ProductList = () => {
       <div className={styles.content}>{mappedItems}</div>
       <Pagination
         currentPage={currentPage}
-        data={paginationRang}
+        data={paginationRange}
         onChange={handleChangePage}
       />
     </div>

--- a/src/entities/questions/index.ts
+++ b/src/entities/questions/index.ts
@@ -1,1 +1,2 @@
 export * from "./ui"
+export type {AnswerState, Question} from "./model/types"

--- a/src/entities/questions/model/types.ts
+++ b/src/entities/questions/model/types.ts
@@ -1,0 +1,11 @@
+export interface Question {
+  id: number
+  title: string
+  answers: string[]
+}
+
+export interface AnswerState {
+  id: number
+  title: string
+  answer: string | null
+}

--- a/src/entities/questions/ui/List/index.tsx
+++ b/src/entities/questions/ui/List/index.tsx
@@ -1,45 +1,64 @@
 import styles from "./QuestionsList.module.scss"
 
-import React, {FC, useEffect, useState} from "react"
+import React, {FC, useEffect, useMemo, useState} from "react"
 
 import cn from "classnames"
+
+import {type AnswerState, type Question} from "../../model/types"
 
 import {CircleStages} from "@shared/ui"
 import {RadioSelect} from "@shared/ui/RadioSelect"
 
-interface IQuestionList {
-  id: number
-  title: string
-  answers: string[]
-}
-
-interface IAnswerList {
-  id: number
-  title: string
-  answer: string | null
-}
-
 interface IQuestionsListProps {
-  data: IQuestionList[]
+  data: Question[]
   onSubmit: () => void
 }
 
 export const QuestionsList: FC<IQuestionsListProps> = ({data, onSubmit}) => {
   const [selectedIndex, setSelectedIndex] = useState(0)
-  const [answers, setAnswers] = useState<IAnswerList[]>()
+  const [answers, setAnswers] = useState<AnswerState[]>(() =>
+    data.map(question => ({
+      id: question.id,
+      title: question.title,
+      answer: null,
+    }))
+  )
   const [error, setError] = useState(false)
 
   useEffect(() => {
-    setAnswers(data.map(el => ({id: el.id, title: el.title, answer: null})))
+    setSelectedIndex(0)
+    setError(false)
+    setAnswers(
+      data.map(question => ({
+        id: question.id,
+        title: question.title,
+        answer: null,
+      }))
+    )
   }, [data])
 
+  const currentQuestion = data[selectedIndex]
+  const currentAnswer = answers[selectedIndex]
+  const isLastStep = selectedIndex === data.length - 1
+  const hasAnswer = currentAnswer?.answer !== null
+
+  const radioSelectDefaultValue = useMemo(
+    () => currentAnswer?.answer ?? "",
+    [currentAnswer?.answer]
+  )
+
+  if (!currentQuestion) {
+    return null
+  }
+
   const handleSetNextIndex = () => {
-    if (answers && answers[selectedIndex].answer !== null) {
-      setSelectedIndex(prevState => prevState + 1)
-      setError(false)
-    } else {
+    if (!hasAnswer) {
       setError(true)
+      return
     }
+
+    setError(false)
+    setSelectedIndex(prevState => Math.min(prevState + 1, data.length - 1))
   }
   const handleSetPrevIndex = () => {
     if (selectedIndex > 0) {
@@ -49,33 +68,32 @@ export const QuestionsList: FC<IQuestionsListProps> = ({data, onSubmit}) => {
   }
 
   const handleSetAnswer = (value: string) => {
-    if (answers) {
-      const newArray: IAnswerList[] = [...answers]
-      newArray[selectedIndex].answer = value
-      setAnswers(newArray)
-    }
+    setAnswers(prevState =>
+      prevState.map((answer, index) =>
+        index === selectedIndex ? {...answer, answer: value} : answer
+      )
+    )
+    setError(false)
   }
 
   const handleSubmit = () => {
-    if (answers && answers[selectedIndex].answer !== null) {
-      onSubmit()
-      setError(false)
-    } else {
+    if (!hasAnswer) {
       setError(true)
+      return
     }
-  }
 
-  const radioSelectDefaultValue =
-    (answers && answers[selectedIndex]?.answer) ?? ""
+    setError(false)
+    onSubmit()
+  }
 
   return (
     <div className={styles.main}>
       <div className={styles.content}>
         <CircleStages countItems={data.length} selectedItem={selectedIndex} />
-        <span className={styles.title}>{data[selectedIndex].title}</span>
+        <span className={styles.title}>{currentQuestion.title}</span>
         <div className={styles.radioSelect}>
           <RadioSelect
-            data={data[selectedIndex].answers}
+            data={currentQuestion.answers}
             defaultValue={radioSelectDefaultValue}
             onChange={handleSetAnswer}
           />
@@ -92,7 +110,7 @@ export const QuestionsList: FC<IQuestionsListProps> = ({data, onSubmit}) => {
         >
           Назад
         </button>
-        {selectedIndex !== data.length - 1 ? (
+        {!isLastStep ? (
           <button
             type="button"
             onClick={handleSetNextIndex}

--- a/src/shared/hooks/usePagination.tsx
+++ b/src/shared/hooks/usePagination.tsx
@@ -21,9 +21,12 @@ export const usePagination = ({
   siblingCount = 1,
   currentPage,
 }: IUsePagination): Array<string | number> => {
-  // eslint-disable-next-line consistent-return
   const paginationRange = useMemo(() => {
     const totalPageCount = Math.ceil(totalCount / pageSize)
+
+    if (totalPageCount <= 0) {
+      return []
+    }
 
     // Pages count is determined as siblingCount + firstPage + lastPage + currentPage + 2*DOTS
     const totalPageNumbers = siblingCount + 5
@@ -64,6 +67,8 @@ export const usePagination = ({
       const middleRange = range(leftSiblingIndex, rightSiblingIndex)
       return [firstPageIndex, DOTS, ...middleRange, DOTS, lastPageIndex]
     }
+
+    return []
   }, [totalCount, pageSize, siblingCount, currentPage])
 
   return paginationRange ?? []

--- a/src/shared/ui/Pagination/index.tsx
+++ b/src/shared/ui/Pagination/index.tsx
@@ -4,6 +4,8 @@ import React, {FC} from "react"
 
 import cn from "classnames"
 
+import {DOTS} from "@shared/hooks/usePagination"
+
 interface IPaginationProps {
   currentPage: number
   data: (string | number)[]
@@ -14,14 +16,14 @@ export const Pagination: FC<IPaginationProps> = React.memo(
   ({data, currentPage, onChange}) => {
     const mappedItems = data.map((el, index) => {
       const handleChangePage = () => {
-        if (el !== "..." && onChange) {
+        if (el !== DOTS && onChange) {
           onChange(el as number)
         }
       }
 
       const itemClasses = cn(styles.item, {
         [styles.active]: el === currentPage,
-        [styles.dots]: el === "...",
+        [styles.dots]: el === DOTS,
       })
       return (
         <div key={index} onClick={handleChangePage} className={itemClasses}>

--- a/src/shared/ui/RadioSelect/index.tsx
+++ b/src/shared/ui/RadioSelect/index.tsx
@@ -17,32 +17,34 @@ export const RadioSelect: FC<IRadioSelect> = ({
   defaultValue,
   onChange,
 }) => {
-  const [selectedValue, setSelectedValue] = useState<string>()
+  const [selectedValue, setSelectedValue] = useState<string>(defaultValue ?? "")
 
   useEffect(() => {
-    setSelectedValue(defaultValue)
+    setSelectedValue(defaultValue ?? "")
   }, [defaultValue])
 
-  const mappedItems = data.map((el, index) => {
+  const mappedItems = data.map(value => {
     const handleSetSelectedValue = () => {
-      if (el !== defaultValue) {
-        setSelectedValue(el)
-        if (onChange) {
-          onChange(el)
-        }
+      if (value === selectedValue) {
+        return
+      }
+
+      setSelectedValue(value)
+      if (onChange) {
+        onChange(value)
       }
     }
 
     return (
       <div
-        key={index}
-        className={cn(styles.item, {[styles.active]: el === selectedValue})}
+        key={value}
+        className={cn(styles.item, {[styles.active]: value === selectedValue})}
         onClick={handleSetSelectedValue}
       >
         <div className={styles.circle}>
           <div className={styles.smallCircle} />
         </div>
-        <span className={styles.text}>{el}</span>
+        <span className={styles.text}>{value}</span>
       </div>
     )
   })

--- a/src/widgets/BeautyQuestionsBlock/ui/index.tsx
+++ b/src/widgets/BeautyQuestionsBlock/ui/index.tsx
@@ -3,9 +3,13 @@
 import React, {useState} from "react"
 
 import {ProductList} from "@entities/product"
-import {QuestionsList, QuestionsListWrapper} from "@entities/questions"
+import {
+  QuestionsList,
+  QuestionsListWrapper,
+  type Question,
+} from "@entities/questions"
 
-const QuestionsListData = [
+const QUESTIONS: Question[] = [
   {
     id: 1,
     title: "Сколько вам лет?",
@@ -44,7 +48,7 @@ export const BeautyQuestionsBlock = () => {
   const content = isSubmitted ? (
     <ProductList />
   ) : (
-    <QuestionsList data={QuestionsListData} onSubmit={handleSubmit} />
+    <QuestionsList data={QUESTIONS} onSubmit={handleSubmit} />
   )
 
   return (


### PR DESCRIPTION
## Summary
- add shared question types and reuse them across the questionnaire flow
- refactor question navigation, selection handling, and pagination helpers for clarity
- simplify product list rendering and switch product images to Next.js Image for better optimization

## Testing
- yarn lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a3d75b47883248df76e1f2590aa0b)